### PR TITLE
bugfix: YYLabel setAttributedText: havn't call textParser to update l…

### DIFF
--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -719,6 +719,10 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
             } break;
             default: break;
         }
+
+        if (_textParser)
+            [_textParser parseText:_innerText selectedRange:NULL];
+        
     } else {
         _innerText = [NSMutableAttributedString new];
     }


### PR DESCRIPTION
A YYLabel that has a textParser should reprocess the text when change the attributedText.