### PR TITLE
fix potential crash bug

### DIFF
--- a/YYText/Component/YYTextLayout.m
+++ b/YYText/Component/YYTextLayout.m
@@ -549,7 +549,7 @@ OSSpinLockUnlock(&_lock);
         if (container.linePositionModifier) {
             [container.linePositionModifier modifyLines:lines fromText:text inContainer:container];
             textBoundingRect = CGRectZero;
-            for (NSUInteger i = 0; i < lineCount; i++) {
+            for (NSUInteger i = 0; i < lines.count; i++) {
                 YYTextLine *line = lines[i];
                 if (i == 0) textBoundingRect = line.bounds;
                 else textBoundingRect = CGRectUnion(textBoundingRect, line.bounds);


### PR DESCRIPTION
When setting `numberOfLines` in `YYLabel`, I find a crash bug here.

To fix this bug, change `lineCount` to `lines.count`.

Detail:
I set `numberOfLines` to 4, if the text has 7 lines. This bug will show.