### PR TITLE
add Nullability

### DIFF
--- a/YYText/YYLabel.h
+++ b/YYText/YYLabel.h
@@ -48,28 +48,28 @@
  Set a new value to this property also replaces the text in `attributedText`.
  Get the value returns the plain text in `attributedText`.
  */
-@property (nullable,nonatomic, copy) NSString *text;
+@property (nullable, nonatomic, copy) NSString *text;
 
 /**
  The font of the text. Default is 12-point system font.
  Set a new value to this property also causes the new font to be applied to the entire `attributedText`.
  Get the value returns the font at the head of `attributedText`.
  */
-@property (nonnull,nonatomic, retain) UIFont *font;
+@property (null_resettable, nonatomic, retain) UIFont *font;
 
 /**
  The color of the text. Default is black.
  Set a new value to this property also causes the new color to be applied to the entire `attributedText`.
  Get the value returns the color at the head of `attributedText`.
  */
-@property (nonnull,nonatomic, retain) UIColor *textColor;
+@property (null_resettable, nonatomic, retain) UIColor *textColor;
 
 /**
  The shadow color of the text. Default is nil.
  Set a new value to this property also causes the shadow color to be applied to the entire `attributedText`.
  Get the value returns the shadow color at the head of `attributedText`.
  */
-@property (nullable,nonatomic, retain) UIColor *shadowColor;
+@property (nullable, nonatomic, retain) UIColor *shadowColor;
 
 /**
  The shadow offset of the text. Default is CGSizeZero.
@@ -105,7 +105,7 @@
  @discussion It only support the attributes declared in CoreText and YYTextAttribute.
  See `NSAttributedString+YYText` for more convenience methods to set the attributes.
  */
-@property (nullable,nonatomic, copy) NSAttributedString *attributedText;
+@property (nullable, nonatomic, copy) NSAttributedString *attributedText;
 
 /**
  The technique to use for wrapping and truncating the label's text.
@@ -117,7 +117,7 @@
  The truncation token string used when text is truncated. Default is nil.
  When the value is nil, the label use "…" as default truncation token.
  */
-@property (nullable,nonatomic, copy) NSAttributedString *truncationToken;
+@property (nullable, nonatomic, copy) NSAttributedString *truncationToken;
 
 /**
  The maximum number of lines to use for rendering text. Default value is 1.
@@ -132,14 +132,14 @@
  
  See `YYTextParser` protocol for more information.
  */
-@property (nullable,nonatomic, strong) id<YYTextParser> textParser;
+@property (nullable, nonatomic, strong) id<YYTextParser> textParser;
 
 /**
  The current text layout in text view. It can be used to query the text layout information.
  Set a new value to this property also replaces most properties in this label, such as `text`,
  `color`, `attributedText`, `lineBreakMode`, `textContainerPath`, `exclusionPaths` and so on.
  */
-@property (nullable,nonatomic, strong) YYTextLayout *textLayout;
+@property (nullable, nonatomic, strong) YYTextLayout *textLayout;
 
 
 #pragma mark - Configuring the Text Container
@@ -150,13 +150,13 @@
 /**
  A UIBezierPath object that specifies the shape of the text frame. Default value is nil.
  */
-@property (nullable,nonatomic, copy) UIBezierPath *textContainerPath;
+@property (nullable, nonatomic, copy) UIBezierPath *textContainerPath;
 
 /**
  An array of UIBezierPath objects representing the exclusion paths inside the
  receiver's bounding rectangle. Default value is nil.
  */
-@property (nullable,nonatomic, copy) NSArray *exclusionPaths;
+@property (nullable, nonatomic, copy) NSArray *exclusionPaths;
 
 /**
  The inset of the text container's layout area within the text view's content area.
@@ -175,13 +175,13 @@
  Default value is nil.
  See `YYTextLinePositionModifier` protocol for more information.
  */
-@property (nullable,nonatomic, copy) id<YYTextLinePositionModifier> linePositionModifier;
+@property (nullable, nonatomic, copy) id<YYTextLinePositionModifier> linePositionModifier;
 
 /**
  The debug option to display CoreText layout result.
  The default value is [YYTextDebugOption sharedDebugOption].
  */
-@property (nonnull,nonatomic, copy) YYTextDebugOption *debugOption;
+@property (nonnull, nonatomic, copy) YYTextDebugOption *debugOption;
 
 
 #pragma mark - Interacting with Text Data
@@ -193,13 +193,13 @@
  When user tap the highlight range of text, this action will be called.
  The default value is nil.
  */
-@property (nullable,nonatomic, copy) YYTextAction highlightTapAction;
+@property (nullable, nonatomic, copy) YYTextAction highlightTapAction;
 
 /**
  When user long press the highlight range of text, this action will be called.
  The default value is nil. 
  */
-@property (nullable,nonatomic, copy) YYTextAction highlightLongPressAction;
+@property (nullable, nonatomic, copy) YYTextAction highlightLongPressAction;
 
 
 #pragma mark - Configuring the Display Mode

--- a/YYText/YYLabel.h
+++ b/YYText/YYLabel.h
@@ -48,28 +48,28 @@
  Set a new value to this property also replaces the text in `attributedText`.
  Get the value returns the plain text in `attributedText`.
  */
-@property (nonatomic, copy) NSString *text;
+@property (nullable,nonatomic, copy) NSString *text;
 
 /**
  The font of the text. Default is 12-point system font.
  Set a new value to this property also causes the new font to be applied to the entire `attributedText`.
  Get the value returns the font at the head of `attributedText`.
  */
-@property (nonatomic, retain) UIFont *font;
+@property (nonnull,nonatomic, retain) UIFont *font;
 
 /**
  The color of the text. Default is black.
  Set a new value to this property also causes the new color to be applied to the entire `attributedText`.
  Get the value returns the color at the head of `attributedText`.
  */
-@property (nonatomic, retain) UIColor *textColor;
+@property (nonnull,nonatomic, retain) UIColor *textColor;
 
 /**
  The shadow color of the text. Default is nil.
  Set a new value to this property also causes the shadow color to be applied to the entire `attributedText`.
  Get the value returns the shadow color at the head of `attributedText`.
  */
-@property (nonatomic, retain) UIColor *shadowColor;
+@property (nullable,nonatomic, retain) UIColor *shadowColor;
 
 /**
  The shadow offset of the text. Default is CGSizeZero.
@@ -105,7 +105,7 @@
  @discussion It only support the attributes declared in CoreText and YYTextAttribute.
  See `NSAttributedString+YYText` for more convenience methods to set the attributes.
  */
-@property (nonatomic, copy) NSAttributedString *attributedText;
+@property (nullable,nonatomic, copy) NSAttributedString *attributedText;
 
 /**
  The technique to use for wrapping and truncating the label's text.
@@ -117,7 +117,7 @@
  The truncation token string used when text is truncated. Default is nil.
  When the value is nil, the label use "…" as default truncation token.
  */
-@property (nonatomic, copy) NSAttributedString *truncationToken;
+@property (nullable,nonatomic, copy) NSAttributedString *truncationToken;
 
 /**
  The maximum number of lines to use for rendering text. Default value is 1.
@@ -132,14 +132,14 @@
  
  See `YYTextParser` protocol for more information.
  */
-@property (nonatomic, strong) id<YYTextParser> textParser;
+@property (nullable,nonatomic, strong) id<YYTextParser> textParser;
 
 /**
  The current text layout in text view. It can be used to query the text layout information.
  Set a new value to this property also replaces most properties in this label, such as `text`,
  `color`, `attributedText`, `lineBreakMode`, `textContainerPath`, `exclusionPaths` and so on.
  */
-@property (nonatomic, strong) YYTextLayout *textLayout;
+@property (nullable,nonatomic, strong) YYTextLayout *textLayout;
 
 
 #pragma mark - Configuring the Text Container
@@ -150,13 +150,13 @@
 /**
  A UIBezierPath object that specifies the shape of the text frame. Default value is nil.
  */
-@property (nonatomic, copy) UIBezierPath *textContainerPath;
+@property (nullable,nonatomic, copy) UIBezierPath *textContainerPath;
 
 /**
  An array of UIBezierPath objects representing the exclusion paths inside the
  receiver's bounding rectangle. Default value is nil.
  */
-@property (nonatomic, copy) NSArray *exclusionPaths;
+@property (nullable,nonatomic, copy) NSArray *exclusionPaths;
 
 /**
  The inset of the text container's layout area within the text view's content area.
@@ -175,13 +175,13 @@
  Default value is nil.
  See `YYTextLinePositionModifier` protocol for more information.
  */
-@property (nonatomic, copy) id<YYTextLinePositionModifier> linePositionModifier;
+@property (nullable,nonatomic, copy) id<YYTextLinePositionModifier> linePositionModifier;
 
 /**
  The debug option to display CoreText layout result.
  The default value is [YYTextDebugOption sharedDebugOption].
  */
-@property (nonatomic, copy) YYTextDebugOption *debugOption;
+@property (nonnull,nonatomic, copy) YYTextDebugOption *debugOption;
 
 
 #pragma mark - Interacting with Text Data
@@ -193,13 +193,13 @@
  When user tap the highlight range of text, this action will be called.
  The default value is nil.
  */
-@property (nonatomic, copy) YYTextAction highlightTapAction;
+@property (nullable,nonatomic, copy) YYTextAction highlightTapAction;
 
 /**
  When user long press the highlight range of text, this action will be called.
  The default value is nil. 
  */
-@property (nonatomic, copy) YYTextAction highlightLongPressAction;
+@property (nullable,nonatomic, copy) YYTextAction highlightLongPressAction;
 
 
 #pragma mark - Configuring the Display Mode

--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -69,6 +69,9 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
 
 @implementation YYLabel
 
+@synthesize font = _font;
+@synthesize textColor = _textColor;
+
 #pragma mark - Private
 
 - (void)_updateIfNeeded {
@@ -334,8 +337,6 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     _debugOption = [YYTextDebugOption sharedDebugOption];
     [YYTextDebugOption addDebugTarget:self];
     
-    _font = [self _defaultFont];
-    _textColor = [UIColor blackColor];
     _textVerticalAlignment = YYTextVerticalAlignmentCenter;
     _numberOfLines = 1;
     _lineBreakMode = NSLineBreakByTruncatingTail;
@@ -563,14 +564,21 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     }
 }
 
+- (UIFont *)font
+{
+    if (!_font) {
+        _font = [self _defaultFont];
+    }
+    return _font;
+}
+
 - (void)setFont:(UIFont *)font {
     if (!font) {
-        _font = [self _defaultFont];
-        return;
+        font = [self _defaultFont];
     }
     if (_font == font || [_font isEqual:font]) return;
     _font = font;
-    _innerText.yy_font = _font ? _font : [self _defaultFont];
+    _innerText.yy_font = _font;
     if (_innerText.length && !_ignoreCommonProperties) {
         if (_displaysAsynchronously && _clearContentsBeforeAsynchronouslyDisplay) {
             [self _clearContents];
@@ -580,9 +588,17 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     }
 }
 
+- (UIColor *)textColor
+{
+    if (!_textColor) {
+        _textColor = [UIColor blackColor];
+    }
+    return _textColor;
+}
+
 - (void)setTextColor:(UIColor *)textColor {
     if (!textColor) {
-        _textColor = [UIColor blackColor];
+        textColor = [UIColor blackColor];
     }
     if (_textColor == textColor || [_textColor isEqual:textColor]) return;
     _textColor = textColor;

--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -334,6 +334,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     _debugOption = [YYTextDebugOption sharedDebugOption];
     [YYTextDebugOption addDebugTarget:self];
     
+    _font = [self _defaultFont];
     _textVerticalAlignment = YYTextVerticalAlignmentCenter;
     _numberOfLines = 1;
     _lineBreakMode = NSLineBreakByTruncatingTail;
@@ -531,7 +532,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     [_innerText replaceCharactersInRange:NSMakeRange(0, _innerText.length) withString:text ? text : @""];
     [_innerText yy_removeDiscontinuousAttributesInRange:NSMakeRange(0, _innerText.length)];
     if (needAddAttributes) {
-        _innerText.yy_font = _font ? _font : [self _defaultFont];
+        _innerText.yy_font = _font;
         _innerText.yy_color = _textColor;
         _innerText.yy_shadow = [self _shadowFromProperties];
         _innerText.yy_alignment = _textAlignment;

--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -564,6 +564,10 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
 }
 
 - (void)setFont:(UIFont *)font {
+    if (!font) {
+        _font = [self _defaultFont];
+        return;
+    }
     if (_font == font || [_font isEqual:font]) return;
     _font = font;
     _innerText.yy_font = _font ? _font : [self _defaultFont];
@@ -577,6 +581,9 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
 }
 
 - (void)setTextColor:(UIColor *)textColor {
+    if (!textColor) {
+        _textColor = [UIColor blackColor];
+    }
     if (_textColor == textColor || [_textColor isEqual:textColor]) return;
     _textColor = textColor;
     _innerText.yy_color = textColor;

--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -335,6 +335,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     [YYTextDebugOption addDebugTarget:self];
     
     _font = [self _defaultFont];
+    _textColor = [UIColor blackColor];
     _textVerticalAlignment = YYTextVerticalAlignmentCenter;
     _numberOfLines = 1;
     _lineBreakMode = NSLineBreakByTruncatingTail;


### PR DESCRIPTION
1.优化初始化方法
2.优化property声明

在初始化过程就设置好初始值,同时property添加Nullability声明。



比如我自己遇到的案例：
~~~objective-c
[UIFont fontWithName:fontModel.fontName size:self.contentLabel.font.pointSize]
~~~
想要设置自定义字体。但是由于`self.contentLabel.font.pointSize`是nil，导致一直设置的是系统字体。