### PR TITLE
增加一个passTapWithOutActionAndHighlight属性

### DIFF
--- a/YYText/YYLabel.h
+++ b/YYText/YYLabel.h
@@ -289,6 +289,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL ignoreCommonProperties;
 
+/**
+ If the value is YES, when tapped on part with no action and no highlight, tap
+ event will be past to responsor under it.
+ 
+ The default value is `NO`.
+ */
+@property (nonatomic) BOOL passTapWithOutActionAndHighlight;
+
 /*
  Tips:
  

--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -525,6 +525,14 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
 
 #pragma mark - Touches
 
+-(UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    _highlight = [self _getHighlightAtPoint:point range:&_highlightRange];
+    if (!_passTapWithOutActionAndHighlight || _highlight || _textTapAction || _textLongPressAction) {
+        return self;
+    }
+    return nil;
+}
+
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
     [self _updateIfNeeded];
     UITouch *touch = touches.anyObject;

--- a/YYText/YYTextView.h
+++ b/YYText/YYTextView.h
@@ -345,6 +345,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) CGFloat extraAccessoryViewHeight;
 
+/**
+ If the value is YES, when tapped on part with no action and no highlight, tap
+ event will be past to responsor under it.
+ 
+ The default value is `NO`.
+ */
+@property (nonatomic) BOOL passTapWithOutActionAndHighlight;
+
 @end
 
 

--- a/YYText/YYTextView.m
+++ b/YYText/YYTextView.m
@@ -2501,6 +2501,18 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
 
 #pragma mark - Override UIResponder
 
+-(UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    if (!self.isFirstResponder && !_state.selectedWithoutEdit && self.highlightable) {
+        _highlight = [self _getHighlightAtPoint:point range:&_highlightRange];
+    }
+    if ((!self.selectable && !_highlight) || _state.ignoreTouchBegan) {
+        if (_passTapWithOutActionAndHighlight) {
+            return nil;
+        }
+    }
+    return self;
+}
+
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
     [self _updateIfNeeded];
     UITouch *touch = touches.anyObject;


### PR DESCRIPTION
增加一个passTapWithOutActionAndHighlight属性，值为YES时，点击“没有tapAction、unHighLighted”的部分，直接透传点击事件；
加这个的原因是因为，如果只是加一个delegate，手动去执行下面view的方法，则必须知道下面的是哪个view的哪个方法，用这个方法可以对此透明。