### PR TITLE
调整_updateOuterProperties中设置的顺序

### DIFF
--- a/YYText/YYTextView.m
+++ b/YYText/YYTextView.m
@@ -1505,9 +1505,9 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
     [self _setFont:font];
     [self _setTextColor:color];
     [self _setTextAlignment:style.alignment];
-    [self _setSelectedRange:_selectedTextRange.asRange];
     [self _setTypingAttributes:_typingAttributesHolder.yy_attributes];
     [self _setAttributedText:_innerText];
+    [self _setSelectedRange:_selectedTextRange.asRange];
 }
 
 /// Parse text with `textParser` and update the _selectedTextRange.


### PR DESCRIPTION
因为调用textDidChangedSelection的时候attributedText还没有更新导致无法在textDidChangedSelection中使用正确的attributedText。