### PR TITLE
添加一个属性使事件可以一直传递下去

### DIFF
--- a/YYText/YYLabel.h
+++ b/YYText/YYLabel.h
@@ -211,6 +211,12 @@ NS_ASSUME_NONNULL_BEGIN
 ///=============================================================================
 
 /**
+ When you implement like textLongPressAction method, the event will be intercepted, and if the alwaysAllowEvents2PassOn is set to true, the event will not be intercepted, the event will continue to pass on.
+ The default value is false;
+ */
+@property (nonatomic, assign) BOOL alwaysAllowEventsToPassOn;
+
+/**
  When user tap the label, this action will be called (similar to tap gesture).
  The default value is nil.
  */

--- a/YYText/YYLabel.h
+++ b/YYText/YYLabel.h
@@ -371,6 +371,7 @@ IB_DESIGNABLE
 @property (nonatomic) UIEdgeInsets textContainerInset;
 @property (nullable, nonatomic, copy) id<YYTextLinePositionModifier> linePositionModifier;
 @property (nonnull, nonatomic, copy) YYTextDebugOption *debugOption;
+@property (nonatomic) BOOL alwaysAllowEventsToPassOn;
 @property (nullable, nonatomic, copy) YYTextAction textTapAction;
 @property (nullable, nonatomic, copy) YYTextAction textLongPressAction;
 @property (nullable, nonatomic, copy) YYTextAction highlightTapAction;

--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -548,7 +548,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
         _state.swallowTouch = NO;
         _state.touchMoved = NO;
     }
-    if (!_state.swallowTouch) {
+    if (!_state.swallowTouch || _alwaysAllowEventsToPassOn) {
         [super touchesBegan:touches withEvent:event];
     }
 }
@@ -582,7 +582,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
         }
     }
     
-    if (!_state.swallowTouch) {
+    if (!_state.swallowTouch || _alwaysAllowEventsToPassOn) {
         [super touchesMoved:touches withEvent:event];
     }
 }
@@ -623,14 +623,16 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
         }
     }
     
-    if (!_state.swallowTouch) {
+    if (!_state.swallowTouch || _alwaysAllowEventsToPassOn) {
         [super touchesEnded:touches withEvent:event];
     }
 }
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
     [self _endTouch];
-    if (!_state.swallowTouch) [super touchesCancelled:touches withEvent:event];
+    if (!_state.swallowTouch || _alwaysAllowEventsToPassOn) {
+        [super touchesCancelled:touches withEvent:event];
+    }
 }
 
 #pragma mark - Properties


### PR DESCRIPTION
您的长按实现方式拦截了事件的继续传递，可我有些场景既需要使用您的长按，也需要事件一直传递下去，所以添加了一个可以使事件一直传递下去的属性，当属性为true的时候，事件就可以一直传递下去。