### PR TITLE
Fix YYLabel  highlight  fade bug

### DIFF
--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -235,7 +235,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
 
 - (void)_endTouch {
     [self _endLongPressTimer];
-    [self _removeHighlightAnimated:YES];
+    [self _removeHighlightAnimated:_fadeOnHighlight];
     _state.trackingTouch = NO;
 }
 


### PR DESCRIPTION
When call "touchesCancelled: withEvent:",  fadeOnHighlight is always YES, which cause highlight content faded in reusing