### PR TITLE
Fix YYTextView selection bug that selection cannot be done when selecting one more line (trigger scrolling action)

### DIFF
--- a/YYText/YYTextView.h
+++ b/YYText/YYTextView.h
@@ -401,6 +401,10 @@ IB_DESIGNABLE
 @end
 #endif // !TARGET_INTERFACE_BUILDER
 
+@interface YYTextView()
+/// Default is nil.
+/// Only for YYTextView embedded in a `ScrollView`. Set this to block superview to respond PanGesture or scrolling action.
+@property (nullable, nonatomic, weak) UIScrollView *interactiveSuperScrollView;
 
 // Notifications, see UITextView's documentation for more information.
 UIKIT_EXTERN NSString *const YYTextViewTextDidBeginEditingNotification;

--- a/YYText/YYTextView.h
+++ b/YYText/YYTextView.h
@@ -406,6 +406,8 @@ IB_DESIGNABLE
 /// Only for YYTextView embedded in a `ScrollView`. Set this to block superview to respond PanGesture or scrolling action.
 @property (nullable, nonatomic, weak) UIScrollView *interactiveSuperScrollView;
 
+@end
+
 // Notifications, see UITextView's documentation for more information.
 UIKIT_EXTERN NSString *const YYTextViewTextDidBeginEditingNotification;
 UIKIT_EXTERN NSString *const YYTextViewTextDidChangeNotification;

--- a/YYText/YYTextView.m
+++ b/YYText/YYTextView.m
@@ -855,11 +855,11 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
         [self _removeHighlightAnimated:NO];
         if (_state.trackingTouch) {
             if (_state.trackingGrabber) {
-                self.panGestureRecognizer.enabled = NO;
+                [self _disablePanGestures];
                 [self _hideMenu];
                 [self _showMagnifierRanged];
             } else if (self.isFirstResponder){
-                self.panGestureRecognizer.enabled = NO;
+                [self _disablePanGestures];
                 _selectionView.caretBlinks = NO;
                 _state.trackingCaret = YES;
                 CGPoint trackingPoint = [self _convertPointToLayout:_trackingPoint];
@@ -884,7 +884,7 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
                     [self _showMagnifierCaret];
                 }
             } else if (self.selectable) {
-                self.panGestureRecognizer.enabled = NO;
+                [self _disablePanGestures];
                 _state.trackingPreSelect = YES;
                 _state.selectedWithoutEdit = NO;
                 [self _updateTextRangeByTrackingPreSelect];
@@ -1030,6 +1030,7 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
     [self _updateSelectionView];
     
     self.panGestureRecognizer.enabled = self.scrollEnabled;
+    self.interactiveSuperScrollView.scrollEnabled = YES;
 }
 
 /// Start a timer to fix the selection dot.
@@ -1047,6 +1048,12 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
 - (void)_endSelectionDotFixTimer {
     [_selectionDotFixTimer invalidate];
     _selectionDotFixTimer = nil;
+}
+
+// Disable scrollView panGesture and interactive superview scroll action
+- (void)_disablePanGestures {
+    self.panGestureRecognizer.enabled = NO; // disable scroll view
+    self.interactiveSuperScrollView.scrollEnabled = NO; // disable interactive superview
 }
 
 /// If it shows selection grabber and this view was moved by super view,
@@ -2500,6 +2507,7 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
     return layout.textBoundingSize;
 }
 
+
 #pragma mark - Override UIResponder
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -2534,7 +2542,7 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
             [self _showHighlightAnimated:NO];
         } else {
             if ([_selectionView isGrabberContainsPoint:point]) { // track grabber
-                self.panGestureRecognizer.enabled = NO; // disable scroll view
+                [self _disablePanGestures];
                 [self _hideMenu];
                 _state.trackingGrabber = [_selectionView isStartGrabberContainsPoint:point] ? kStart : kEnd;
                 _magnifierRangedOffset = [self _getMagnifierRangedOffset];
@@ -2542,7 +2550,7 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
                 if (_selectedTextRange.asRange.length == 0 && self.isFirstResponder) {
                     if ([_selectionView isCaretContainsPoint:point]) { // track caret
                         _state.trackingCaret = YES;
-                        self.panGestureRecognizer.enabled = NO; // disable scroll view
+                        [self _disablePanGestures];
                     }
                 }
             }
@@ -2583,7 +2591,7 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
         } else {
             _trackingRange = _selectedTextRange;
             if (_state.trackingGrabber) {
-                self.panGestureRecognizer.enabled = NO;
+                [self _disablePanGestures];
                 [self _hideMenu];
                 [self _updateTextRangeByTrackingGrabber];
                 showMagnifierRanged = YES;
@@ -2596,11 +2604,11 @@ typedef NS_ENUM(NSUInteger, YYTextMoveDirection) {
                     [self _hideMenu];
                     if (_verticalForm) {
                         if (_state.touchMoved == kTop || _state.touchMoved == kBottom) {
-                            self.panGestureRecognizer.enabled = NO;
+                            [self _disablePanGestures];
                         }
                     } else {
                         if (_state.touchMoved == kLeft || _state.touchMoved == kRight) {
-                            self.panGestureRecognizer.enabled = NO;
+                            [self _disablePanGestures];
                         }
                     }
                     [self _updateTextRangeByTrackingCaret];


### PR DESCRIPTION
YYTextView 嵌套进 UIScrollView (一般是 UITableView)中时, 使用选择功能选择多行数据时同时会触发 UIScrollView 滚动, 导致无法选择多行. 

修复这个 bug. 增加了一个嵌套时需要共同响应的属性 `interactiveSuperScrollView`, 设置后, 将会正常屏蔽 UIScrollView 的滚动.

### 鉴于可能导致功能异常的问题, 没有采用自动方案
当然可以更加自动, 检测父 View 为 ScrollView, 但是这样的话, 在复杂逻辑时, 比如父 View 有 2 个以上的 ScrollView , 其中有部分业务代码还控制 `scrollEnabled` 的属性, 则可能导致功能异常.