### PR TITLE
[fix]: blocking system assertions

### DIFF
--- a/YYText/Utility/YYTextAsyncLayer.m
+++ b/YYText/Utility/YYTextAsyncLayer.m
@@ -155,6 +155,9 @@ static dispatch_queue_t YYTextAsyncLayerGetReleaseQueue() {
                 CGColorRelease(backgroundColor);
                 return;
             }
+            if ((size.width == 0) || (size.height == 0)) {
+                return;
+            }
             UIGraphicsBeginImageContextWithOptions(size, opaque, scale);
             CGContextRef context = UIGraphicsGetCurrentContext();
             if (opaque) {
@@ -198,6 +201,9 @@ static dispatch_queue_t YYTextAsyncLayerGetReleaseQueue() {
             });
         });
     } else {
+        if ((self.bounds.size.width == 0) || (self.bounds.size.height == 0)) {
+            return;
+        }
         [_sentinel increase];
         if (task.willDisplay) task.willDisplay(self);
         UIGraphicsBeginImageContextWithOptions(self.bounds.size, self.opaque, self.contentsScale);


### PR DESCRIPTION
iOS 17 会在 debug 模式下 走到系统断言 

*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={337, 0}, scale=3.000000, bitmapInfo=0x2002. Use UIGraphicsImageRenderer to avoid this assert.'
*** First throw call stack:
(0x1a910c870 0x1a140bc00 0x1a8676e54 0x1ab338380 0x11b2454d8 0x11b244d6c 0x1aa68be54 0x1aa692278 0x1aa68b574 0x1ab2ee970 0x1ab2ee468 0x1ab2edb58 0x1ab2edc14 0x1a905731c 0x1a9056598 0x1a9054d4c 0x1a9053a88 0x1a9053668 0x1ec41e5ec 0x1ab470294 0x1ab46f8d0 0x102bbc2f0 0x1cbaa6dcc)
libc++abi: terminating due to uncaught exception of type NSException
*** Assertion failure in void _UIGraphicsBeginImageContextWithOptions(CGSize, BOOL, CGFloat, BOOL)(), UIGraphics.m:410

临时方案，阻止断言的触发 
如果可能，使用 UIGraphicsImageRenderer 替代 UIGraphicsBeginImageContext()，因为它能更好地处理这种情况。